### PR TITLE
OT192 34 Integration of API Slides

### DIFF
--- a/app/src/main/java/com/melvin/ongandroid/model/HomeWelcome.kt
+++ b/app/src/main/java/com/melvin/ongandroid/model/HomeWelcome.kt
@@ -1,5 +1,7 @@
 package com.melvin.ongandroid.model
 
+import com.melvin.ongandroid.utils.convertHtmlToString
+
 /**
  * Home welcome
  * See a presentation of the activities carried out by SOMOS MAS
@@ -13,4 +15,17 @@ data class HomeWelcome(
     var title: String = "",
     var imgUrl: String = "",
     var description: String = ""
+)
+
+/**
+ * To UI
+ * extension function to convert 'Slide' object received by API to "HomeWelcome" object needed in the UI
+ * created on 24 April 2022 by Leonel Gomez
+ *
+ * @return a HomeWelcome object with the attributes needed by the UI
+ */
+fun Slide.toUI(): HomeWelcome = HomeWelcome(
+    title = name.convertHtmlToString(),
+    imgUrl = image,
+    description = description.convertHtmlToString(),
 )

--- a/app/src/main/java/com/melvin/ongandroid/model/Slide.kt
+++ b/app/src/main/java/com/melvin/ongandroid/model/Slide.kt
@@ -1,0 +1,35 @@
+package com.melvin.ongandroid.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Slide
+ * Data class to get a list of slides
+ * created on 24 April 2022 by Leonel Gomez
+ *
+ * @property id    integer($int32)
+ * @property name   string
+ * @property description    string
+ * @property image  string
+ * @property order  integer($int32) update: some responses are null
+ * @property userId integer($int32) update: some responses are null
+ * @property createdAt  string($date-time)
+ * @property updatedAt  string($date-time)
+ * @property deletedAt  string($date-time) update: some responses are null
+ * @constructor Create empty Slide
+ */
+data class Slide(
+    var id: Int = 0,
+    var name: String = "",
+    var description: String = "",
+    var image: String = "",
+    var order: Int? = 0,
+    @SerializedName("user_id")
+    var userId: Int? = 0,
+    @SerializedName("created_at")
+    var createdAt: String = "",
+    @SerializedName("updated_at")
+    var updatedAt: String = "",
+    @SerializedName("deleted_at")
+    var deletedAt: String? = "",
+)

--- a/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
+++ b/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
@@ -4,6 +4,7 @@ package com.melvin.ongandroid.repository
 import com.melvin.ongandroid.model.HomeTestimonials
 import com.melvin.ongandroid.model.GenericResponse
 import com.melvin.ongandroid.model.NewsResponse
+import com.melvin.ongandroid.model.Slide
 import com.melvin.ongandroid.services.OngApiService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -22,5 +23,17 @@ class OngRepository @Inject constructor(private val apiService: OngApiService) {
      */
     suspend fun fetchLatestNews(): Flow<NewsResponse> = flow {
         emit(apiService.fetchLatestNews())
+    }
+
+    /**
+     * Get slides
+     * Repository function that return the list of slides from the API
+     * created on 24 April 2022 by Leonel Gomez
+     *
+     * @return the list of Slides emitted by upstream
+     */
+    suspend fun getSlides(): Flow<GenericResponse<List<Slide>>> = flow {
+        //Collects the value emitted by the upstream
+        emit(apiService.getSlides())
     }
 }

--- a/app/src/main/java/com/melvin/ongandroid/services/OngApiService.kt
+++ b/app/src/main/java/com/melvin/ongandroid/services/OngApiService.kt
@@ -3,7 +3,9 @@ package com.melvin.ongandroid.services
 import com.melvin.ongandroid.model.HomeTestimonials
 import com.melvin.ongandroid.model.GenericResponse
 import com.melvin.ongandroid.model.NewsResponse
+import com.melvin.ongandroid.model.Slide
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface OngApiService {
 
@@ -13,5 +15,22 @@ interface OngApiService {
   
     @GET("news")
     suspend fun fetchLatestNews() : NewsResponse
+
+    /**
+     * Get slides
+     * slides request to API
+     * created on 24 April 2022 by Leonel Gomez
+     *
+     * @param search    String: Term of search
+     * @param skip  Integer: Total entries to skip in result
+     * @param limit Integer: Total entries to retrieve
+     * @return a GenericResponse (success, data, message) where data is of type list of slides
+     */
+    @GET("slides")
+    suspend fun getSlides(
+        @Query("search") search: String? = null,
+        @Query("skip") skip: Int? = null,
+        @Query("limit") limit: Int? = null,
+    ): GenericResponse<List<Slide>>
 
 }

--- a/app/src/main/java/com/melvin/ongandroid/utils/Utils.kt
+++ b/app/src/main/java/com/melvin/ongandroid/utils/Utils.kt
@@ -1,5 +1,8 @@
 package com.melvin.ongandroid.utils
 
+import android.text.Html
+import android.text.Spanned
+
 /*
 Function that Checks if a String is a valid form of email.
  */
@@ -19,3 +22,18 @@ fun String.checkFirstOrLastName() =
  */
 
 fun String.checkContactMessage(): Boolean = this.isNotEmpty() && this.length >= 30
+
+/**
+ * Convert HTML to string
+ * Return the displayable styled text from the provided HTML string
+ * created on 24 April 2022 by Leonel Gomez
+ *
+ */
+fun String.convertHtmlToString(): String {
+    //As fromHtml is deprecated, whe need to ask for Build version to includes the new int parameter
+    return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+        Html.fromHtml(this, Html.FROM_HTML_MODE_LEGACY).toString()
+    } else {
+        Html.fromHtml(this).toString()
+    }
+}

--- a/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
@@ -10,10 +10,9 @@ import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.melvin.ongandroid.R
 import com.melvin.ongandroid.databinding.FragmentHomeBinding
-import com.melvin.ongandroid.model.HomeWelcome
 import com.melvin.ongandroid.view.adapters.HomeWelcomeItemAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.melvin.ongandroid.model.Novedades
+import com.melvin.ongandroid.model.toUI
 import com.melvin.ongandroid.view.adapters.HomeTestimonialsItemAdapter
 import com.melvin.ongandroid.view.adapters.NovedadesAdapter
 import com.melvin.ongandroid.viewmodel.HomeViewModel
@@ -30,8 +29,6 @@ class HomeFragment : Fragment() {
 
     private lateinit var recyclerViewNovedades: RecyclerView
     private val adapter by lazy { NovedadesAdapter() }
-
-    private val homeViewModel: HomeViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -93,28 +90,36 @@ class HomeFragment : Fragment() {
 
     /**
      * Setup recycler view slider welcome
+     * created on 19 April 2022 by Leonel Gomez
+     * updated on 24 April 2022 by Leonel Gomez
      */
     private fun setupRecyclerViewSliderWelcome() {
-        //TODO: Harcoded random list
-        val listHomeWelcome = MutableList(15) {
-            HomeWelcome(
-                title = "Actividad ${(1..100).random()}",
-                imgUrl = "https://picsum.photos/200/300?random=${(1..100).random()}",
-                description = "Descripción ${(1..100).random()}\n" +
-                        "Descripción ${(1..100).random()}\n" +
-                        "Descripción ${(1..100).random()}\n" +
-                        "Descripción ${(1..100).random()}"
-            )
-        }
-
-        adapterWelcome.submitList(listHomeWelcome)
         adapterWelcome.onItemClicked = { }
+        //It is a horizontal recycler view
         val layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
 
+        //Initial configuration of recycler view
         with(binding) {
             incSectionWelcome.rvSliderWelcome.setHasFixedSize(true)
             incSectionWelcome.rvSliderWelcome.layoutManager = layoutManager
             incSectionWelcome.rvSliderWelcome.adapter = adapterWelcome
+        }
+
+        //the list is populated from a repository asynchronously and updated in live data
+        homeViewModel.slideList.observe(viewLifecycleOwner) { result ->
+            if (!result.isNullOrEmpty()) {
+                //If data is obtained, it is loaded into the recycler adapter
+                //There is a conversion (mapping) of Slide object to HomeWelcome object
+                // (with enough attributes to display in the UI)
+                adapterWelcome.submitList(result.map { it.toUI() })
+                binding.incSectionWelcome.rvSliderWelcome.adapter = adapterWelcome
+
+                //The section is displayed
+                showHomeWelcomeSection()
+            } else {
+                //If the list is empty, this section is hidden
+                showHomeWelcomeSection(show = false)
+            }
         }
     }
 
@@ -147,6 +152,22 @@ class HomeFragment : Fragment() {
         }
 
 
+    }
+
+    /**
+     * Show home welcome section
+     * Show (or hide) home welcome section (title and recycler view)
+     * created on 24 April 2022 by Leonel Gomez
+     *
+     * @param show Boolean default true, to indicate the show or hide (false) action
+     */
+    private fun showHomeWelcomeSection(show: Boolean = true) {
+        with(binding) {
+            if (show)
+                incSectionWelcome.root.visibility = View.VISIBLE
+            else
+                incSectionWelcome.root.visibility = View.GONE
+        }
     }
 
 }

--- a/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
@@ -1,13 +1,8 @@
 package com.melvin.ongandroid.viewmodel
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import com.melvin.ongandroid.model.HomeTestimonials
-import com.melvin.ongandroid.model.GenericResponse
-import com.melvin.ongandroid.model.NewsResponse
+import androidx.lifecycle.*
+import com.melvin.ongandroid.model.*
 import javax.inject.Inject
-import androidx.lifecycle.viewModelScope
 import com.melvin.ongandroid.repository.OngRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers.IO
@@ -21,10 +16,19 @@ class HomeViewModel @Inject constructor(private val repo: OngRepository) : ViewM
     
     private val _newsResponse: MutableLiveData<NewsResponse> = MutableLiveData(NewsResponse())
     val newsResponse: LiveData<NewsResponse> = _newsResponse
-    
+
+    /**
+     * slide list of MutableLiveData type
+     * created on 24 April 2022 by Leonel Gomez
+     */
+    private val _slideList = MutableLiveData<List<Slide>>()
+    val slideList: LiveData<List<Slide>> = _slideList
+
     init {
         getTestimonials()
         fetchLatestNews()
+        //get a list of slides on ViewModel init
+        fetchSlides()
     }
 
     // Function that gets the testimonials and post it in the _testimonials MutableLiveData
@@ -44,6 +48,28 @@ class HomeViewModel @Inject constructor(private val repo: OngRepository) : ViewM
         viewModelScope.launch(IO) {
             repo.fetchLatestNews().collect{ newsResponse ->
                 _newsResponse.postValue(newsResponse)
+            }
+        }
+    }
+
+    /**
+     * Fetch slides
+     * from repository
+     * created on 24 April 2022 by Leonel Gomez
+     */
+    private fun fetchSlides() {
+        //coroutine to get the listing asynchronously
+        viewModelScope.launch(IO) {
+            repo.getSlides().collect { response ->
+                try {
+                    if (response.success)
+                        _slideList.postValue(response.data!!)
+                    else
+                        _slideList.postValue(listOf())
+
+                } catch (e: Exception) {
+                    _slideList.postValue(listOf())
+                }
             }
         }
     }

--- a/app/src/main/res/layout/item_recycler_home_welcome.xml
+++ b/app/src/main/res/layout/item_recycler_home_welcome.xml
@@ -42,6 +42,7 @@
             android:layout_gravity="center"
             android:gravity="top|center"
             android:padding="8dp"
+            android:singleLine="false"
             android:text="@string/item_welcome_default_description"
             android:textAppearance="@style/TextAppearance.AppCompat.Body1"
             android:textColor="@android:color/black"


### PR DESCRIPTION
OT192 34 Integration of API Slides
**resume**
When entering the "Home" view, the endpoint "/api/slides" is consulted and a list of SOMOS MAS activities is returned, which is displayed on the screen along with the "name" and "description" fields. If the list is empty, that section is hidden.

**code**
- creation of data class Slide with all the properties of the endpoint response
- in HomeWelcome includes an extension function toUI to convert Retrofit data into UI
- in Utils, include the extension function convertHtmlToString to return the displayable styled text from the provided HTML string
- in OngApiService includes the suspend function getSlides to access to the API
- in OngRepository includes the suspend function getSlides with flow structure
- in HomeViewModel includes the function fetchSlides in the init fuction, this function get the listing of slides asynchronously from the repository (without contemplating errors for now) and update a livedata "slideList"
- in HomeFragment: the repeated line of homeViewModel is eliminated; in setupRecyclerViewSliderWelcome an observer is incorporated to complete the list of the Home Slides recycler view, when the list is empty (or null) the section is hidden, else is showed. for this purpose, the showHomeWelcomeSection was created
- in item_recycler_home_welcome: the line of description is extended.