### PR TITLE
Ot192 42 unificar falla masiva

### DIFF
--- a/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
+++ b/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
@@ -7,7 +7,9 @@ import com.melvin.ongandroid.model.GenericResponse
 import com.melvin.ongandroid.model.NewsResponse
 import com.melvin.ongandroid.model.Slide
 import com.melvin.ongandroid.services.OngApiService
+import com.melvin.ongandroid.utils.Resource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
@@ -22,25 +24,34 @@ class OngRepository @Inject constructor(private val apiService: OngApiService) {
     /*
     Function that emits a NewsResponse, containing list Of News
      */
-    suspend fun fetchLatestNews(): Flow<NewsResponse> = flow {
-        emit(apiService.fetchLatestNews())
+    suspend fun fetchLatestNews(): Flow<Resource<NewsResponse?>> = flow {
+        val response = apiService.fetchLatestNews()
+
+        when (response.isSuccessful) {
+            true -> emit(Resource.Success(response.body()))
+            false -> emit(Resource.ErrorApi(response.errorBody().toString()))
+        }
+    }.catch { e: Throwable ->
+        emit(Resource.ErrorThrowable(e))
     }
 
 
-    // Function that emits a GenericResponse, containing a contact response
-    suspend fun sendContact(contact:Contact): Flow<GenericResponse<List<Contact>>> = flow {
-        emit(apiService.sendContact(contact))
-    }
-    /**
-     * Get slides
-     * Repository function that return the list of slides from the API
-     * created on 24 April 2022 by Leonel Gomez
-     *
-     * @return the list of Slides emitted by upstream
-     */
-    suspend fun getSlides(): Flow<GenericResponse<List<Slide>>> = flow {
-        //Collects the value emitted by the upstream
-        emit(apiService.getSlides())
 
-    }
+// Function that emits a GenericResponse, containing a contact response
+suspend fun sendContact(contact: Contact): Flow<GenericResponse<List<Contact>>> = flow {
+    emit(apiService.sendContact(contact))
+}
+
+/**
+ * Get slides
+ * Repository function that return the list of slides from the API
+ * created on 24 April 2022 by Leonel Gomez
+ *
+ * @return the list of Slides emitted by upstream
+ */
+suspend fun getSlides(): Flow<GenericResponse<List<Slide>>> = flow {
+    //Collects the value emitted by the upstream
+    emit(apiService.getSlides())
+
+}
 }

--- a/app/src/main/java/com/melvin/ongandroid/services/OngApiService.kt
+++ b/app/src/main/java/com/melvin/ongandroid/services/OngApiService.kt
@@ -5,6 +5,7 @@ import com.melvin.ongandroid.model.HomeTestimonials
 import com.melvin.ongandroid.model.GenericResponse
 import com.melvin.ongandroid.model.NewsResponse
 import com.melvin.ongandroid.model.Slide
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
@@ -19,7 +20,7 @@ interface OngApiService {
     suspend fun getTestimonials(): GenericResponse<MutableList<HomeTestimonials>>
   
     @GET("news")
-    suspend fun fetchLatestNews() : NewsResponse
+    suspend fun fetchLatestNews() : Response<NewsResponse>
 
 
     // Post a new contact to the API

--- a/app/src/main/java/com/melvin/ongandroid/utils/Resource.kt
+++ b/app/src/main/java/com/melvin/ongandroid/utils/Resource.kt
@@ -1,0 +1,30 @@
+package com.melvin.ongandroid.utils
+
+/**
+ * Wrapper class for handling states on API requests.
+ * States:
+ * [Success] ==> When Api Response is succesfull
+ * [ErrorThrowable] ==> Handles Exception like IO
+ * [ErrorApi] ==> Handles unsuccessfully request to API
+ * [Loading] ==> Handles the state of Loading
+ */
+sealed class Resource<T>(
+    val data: T? = null,
+    val errorThrowable: Throwable? = null,
+    val errorMessage:String?=null
+) {
+    class Success<T>(data: T): Resource<T>(data)
+    class ErrorThrowable<T>(errorThrowable: Throwable, data: T? = null): Resource<T>(data, errorThrowable)
+    class ErrorApi<T>(errorMessage:String): Resource<T>(errorMessage = errorMessage)
+    class Loading<T>(data: T? = null): Resource<T>(data)
+
+    /**
+     * This Companion Object simplifies the uses of states, especially to handle errors in flow.
+     */
+    companion object{
+        fun <T> success(data: T): Resource<T> = Success(data)
+        fun <T> errorThrowable(errorThrowable: Throwable): Resource<T> = ErrorThrowable( errorThrowable)
+        fun <T> errorApi(errorMessage:String): Resource<T> = ErrorApi(errorMessage)
+        fun <T> loading(): Resource<T> = Loading()
+    }
+}

--- a/app/src/main/java/com/melvin/ongandroid/utils/Utils.kt
+++ b/app/src/main/java/com/melvin/ongandroid/utils/Utils.kt
@@ -2,6 +2,7 @@ package com.melvin.ongandroid.utils
 
 import android.text.Html
 import android.text.Spanned
+import android.view.View
 
 /*
 Function that Checks if a String is a valid form of email.
@@ -36,4 +37,14 @@ fun String.convertHtmlToString(): String {
     } else {
         Html.fromHtml(this).toString()
     }
+}
+
+fun View.visible(): View {
+    this.visibility = View.VISIBLE
+    return this
+}
+
+fun View.gone(): View {
+    this.visibility = View.GONE
+    return this
 }

--- a/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
@@ -1,6 +1,7 @@
 package com.melvin.ongandroid.view
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -46,16 +47,6 @@ class HomeFragment : Fragment() {
         binding.textViewNovedadesHome.text = getString(R.string.novedades_titulo_home)
 
 
-
-
-        /*  Observe Changes in HomeViewModel for latest News
-           When news is empty hide Section. When Not, set adapter
-           and show only 4 elemtns*/
-
-
-
-
-
         //Configuration of Welcome section
         binding.incSectionWelcome.tvTitleWelcome.text =
             getString(R.string.fragment_home_title_welcome)
@@ -68,10 +59,12 @@ class HomeFragment : Fragment() {
             getString(R.string.fragment_home_title_testimonials)
         setupRecyclerViewSilderTestimonials()
 
+        homeViewModel.massiveFailure.observe(viewLifecycleOwner) {
+            checkMassiveFailure(it)
+        }
+
         return binding.root
     }
-
-
 
 
     /**
@@ -112,10 +105,10 @@ class HomeFragment : Fragment() {
     /**
      * Set Up Recycler View News with States from ViewModel
      * When [Resource.Success] -> Make Visible Recycler
-     * Else -> Make Invisible Recyler
+     * Else -> Make Invisible RecylerView
      */
 
-    private fun setUpRecyclerViewNews(){
+    private fun setUpRecyclerViewNews() {
         recyclerViewNovedades = binding.recyclerNovedadesHome
 
         recyclerViewNovedades.layoutManager =
@@ -125,14 +118,13 @@ class HomeFragment : Fragment() {
 
         homeViewModel.newsState.observe(viewLifecycleOwner) { estadoNoticias ->
             binding.apply {
-                when(estadoNoticias){
-                    is Resource.Success ->{
+                when (estadoNoticias) {
+                    is Resource.Success -> {
                         adapter.submitList(estadoNoticias.data!!.novedades.take(5))
                         textViewNovedadesHome.visible()
                         recyclerNovedadesHome.visible()
                     }
-                    else ->{
-
+                    else -> {
                         textViewNovedadesHome.gone()
                         recyclerNovedadesHome.gone()
                     }
@@ -192,4 +184,30 @@ class HomeFragment : Fragment() {
         }
     }
 
+    /**
+     * When all api calls are unsuccesfull hide current view, and sow new view
+     * with Error Button to retry ApiCalls
+     */
+
+    private fun checkMassiveFailure(massiveFailure: Boolean = false) {
+        binding.apply {
+            when (massiveFailure) {
+                true -> {
+                    constraintLayoutError.visibility = View.VISIBLE
+                    scvHome.visibility = View.GONE
+
+                    buttonError.setOnClickListener {
+                        homeViewModel.retryApiCallsHome()
+                    }
+                }
+                false -> {
+                    constraintLayoutError.visibility = View.GONE
+                    scvHome.visibility = View.VISIBLE
+
+                }
+            }
+        }
+    }
+
 }
+

--- a/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
@@ -13,6 +13,9 @@ import com.melvin.ongandroid.databinding.FragmentHomeBinding
 import com.melvin.ongandroid.view.adapters.HomeWelcomeItemAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.melvin.ongandroid.model.toUI
+import com.melvin.ongandroid.utils.Resource
+import com.melvin.ongandroid.utils.gone
+import com.melvin.ongandroid.utils.visible
 import com.melvin.ongandroid.view.adapters.HomeTestimonialsItemAdapter
 import com.melvin.ongandroid.view.adapters.NovedadesAdapter
 import com.melvin.ongandroid.viewmodel.HomeViewModel
@@ -42,42 +45,23 @@ class HomeFragment : Fragment() {
 
         binding.textViewNovedadesHome.text = getString(R.string.novedades_titulo_home)
 
-        recyclerViewNovedades = binding.recyclerNovedadesHome
 
-        recyclerViewNovedades.layoutManager =
-            LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
-
-        recyclerViewNovedades.adapter = adapter
 
 
         /*  Observe Changes in HomeViewModel for latest News
            When news is empty hide Section. When Not, set adapter
            and show only 4 elemtns*/
-        homeViewModel.newsResponse.observe(viewLifecycleOwner) { newsResponse ->
-            binding.apply {
-                when (newsResponse.novedades.isNotEmpty()) {
-                    true -> {
-                        adapter.submitList(newsResponse.novedades.take(5))
-                        textViewNovedadesHome.visibility = View.VISIBLE
-                        recyclerNovedadesHome.visibility = View.VISIBLE
-                    }
-                    false -> {
-
-                        textViewNovedadesHome.visibility = View.GONE
-                        recyclerNovedadesHome.visibility = View.GONE
-
-                    }
-                }
-            }
 
 
-        }
+
 
 
         //Configuration of Welcome section
         binding.incSectionWelcome.tvTitleWelcome.text =
             getString(R.string.fragment_home_title_welcome)
         setupRecyclerViewSliderWelcome()
+
+        setUpRecyclerViewNews()
 
         //Configuration of Testimonials section
         binding.incSectionTestimonials.tvTitleTestimonials.text =
@@ -86,6 +70,8 @@ class HomeFragment : Fragment() {
 
         return binding.root
     }
+
+
 
 
     /**
@@ -124,20 +110,56 @@ class HomeFragment : Fragment() {
     }
 
     /**
+     * Set Up Recycler View News with States from ViewModel
+     * When [Resource.Success] -> Make Visible Recycler
+     * Else -> Make Invisible Recyler
+     */
+
+    private fun setUpRecyclerViewNews(){
+        recyclerViewNovedades = binding.recyclerNovedadesHome
+
+        recyclerViewNovedades.layoutManager =
+            LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+
+        recyclerViewNovedades.adapter = adapter
+
+        homeViewModel.newsState.observe(viewLifecycleOwner) { estadoNoticias ->
+            binding.apply {
+                when(estadoNoticias){
+                    is Resource.Success ->{
+                        adapter.submitList(estadoNoticias.data!!.novedades.take(5))
+                        textViewNovedadesHome.visible()
+                        recyclerNovedadesHome.visible()
+                    }
+                    else ->{
+
+                        textViewNovedadesHome.gone()
+                        recyclerNovedadesHome.gone()
+                    }
+
+
+                }
+            }
+        }
+    }
+
+
+    /**
      * Setup recycler view slider testimonials
      * Observe changes in HomeViewModel for testimonials.
      * When testimonials is empty hide section, but when not, show section with only 4 elements
      */
     private fun setupRecyclerViewSilderTestimonials() {
 
-        homeViewModel.testimonials.observe(viewLifecycleOwner){response ->
+        homeViewModel.testimonials.observe(viewLifecycleOwner) { response ->
             binding.apply {
-                when (!response.data.isNullOrEmpty()){
+                when (!response.data.isNullOrEmpty()) {
                     true -> {
                         adapterTestimonials.submitList(response.data.take(4).toMutableList())
 
                         adapterTestimonials.onItemClicked = { }
-                        val layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+                        val layoutManager =
+                            LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
 
                         incSectionTestimonials.rvSliderTestimonials.setHasFixedSize(true)
                         incSectionTestimonials.rvSliderTestimonials.layoutManager = layoutManager

--- a/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
@@ -111,9 +111,9 @@ class HomeViewModel @Inject constructor(private val repo: OngRepository) : ViewM
         viewModelScope.launch(IO) {
             delay(5000)
             _massiveFailure.postValue(
-                _newsState.value is Resource.Success &&
-                        !_slideList.value.isNullOrEmpty() &&
-                        !_testimonials.value?.data.isNullOrEmpty()
+                _newsState.value?.data?.success == false &&
+                        _slideList.value?.isNotEmpty() == false &&
+                        _testimonials.value?.success == false
             )
         }
     }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -6,12 +6,51 @@
     android:layout_height="match_parent"
     tools:context=".view.HomeFragment">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraintLayout_error"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/textView_error_masivo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="228dp"
+            android:text="@string/massive_error"
+            android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+            android:textColor="@color/black"
+            android:visibility="visible"
+            app:layout_constraintBottom_toTopOf="@+id/buttonError"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
+
+        <Button
+            android:id="@+id/buttonError"
+            android:layout_width="219dp"
+            android:layout_height="97dp"
+            android:layout_marginBottom="252dp"
+            android:text="@string/retry_button"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.557"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
     <ScrollView
         android:id="@+id/scv_home"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="@string/app_name"
         android:fillViewport="true"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -29,6 +68,7 @@
                 layout="@layout/section_welcome"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:visibility="visible"
                 app:layout_constraintBottom_toTopOf="@id/textView_novedades_home"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -45,10 +85,11 @@
                 android:textAppearance="@style/TextAppearance.AppCompat.Body1"
                 android:textSize="30sp"
                 android:textStyle="bold"
+                android:visibility="visible"
+                app:layout_constraintBottom_toTopOf="@id/recycler_novedades_home"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/inc_section_welcome"
-                app:layout_constraintBottom_toTopOf="@id/recycler_novedades_home"/>
+                app:layout_constraintTop_toBottomOf="@id/inc_section_welcome" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recycler_novedades_home"
@@ -58,10 +99,11 @@
                 android:layout_marginTop="56dp"
                 android:layout_marginEnd="20dp"
                 android:orientation="horizontal"
+                android:visibility="visible"
+                app:layout_constraintBottom_toTopOf="@id/inc_section_testimonials"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/textView_novedades_home"
-                app:layout_constraintBottom_toTopOf="@id/inc_section_testimonials"
                 tools:itemCount="2"
                 tools:listitem="@layout/novedades_item" />
 
@@ -71,10 +113,12 @@
                 layout="@layout/section_testimonials"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:visibility="visible"
                 app:layout_constraintBottom_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/recycler_novedades_home" />
+
             <!-- Fin Sección Testimonios -->
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,5 +31,7 @@
 
     <!-- Image content description in layouts -->
     <string name="content_description_loading">Cargando</string>
+    <string name="massive_error">Error General</string>
+    <string name="retry_button">Reintentar</string>
 
 </resources>


### PR DESCRIPTION
Agregué lógica para unificar los errores en las request. En caso de que los tres servicios fallen se muestra otro layout con una leyenda con el error como también un botón que vuelve a intentar la llamada. A su vez, agregué un wrapper class y se lo apliqué a news response. De esta forma puedo manejar estados de éxito, de error y de carga.