### PR TITLE
Leonelg/ot192 35 exceptions slider

### DIFF
--- a/app/src/main/java/com/melvin/ongandroid/utils/Resource.kt
+++ b/app/src/main/java/com/melvin/ongandroid/utils/Resource.kt
@@ -13,17 +13,22 @@ sealed class Resource<T>(
     val errorThrowable: Throwable? = null,
     val errorMessage:String?=null
 ) {
-    class Success<T>(data: T): Resource<T>(data)
-    class ErrorThrowable<T>(errorThrowable: Throwable, data: T? = null): Resource<T>(data, errorThrowable)
-    class ErrorApi<T>(errorMessage:String): Resource<T>(errorMessage = errorMessage)
-    class Loading<T>(data: T? = null): Resource<T>(data)
+    class Success<T>(data: T) : Resource<T>(data)
+    class ErrorThrowable<T>(errorThrowable: Throwable, data: T? = null) :
+        Resource<T>(data, errorThrowable)
+
+    class ErrorApi<T>(errorMessage: String) : Resource<T>(errorMessage = errorMessage)
+    class Loading<T>(data: T? = null) : Resource<T>(data)
 
     /**
      * This Companion Object simplifies the uses of states, especially to handle errors in flow.
      */
-    companion object{
+    companion object {
         fun <T> success(data: T): Resource<T> = Success(data)
-        fun <T> errorThrowable(errorThrowable: Throwable): Resource<T> = ErrorThrowable( errorThrowable)
-        fun <T> errorApi(errorMessage:String): Resource<T> = ErrorApi(errorMessage)
+        fun <T> errorThrowable(errorThrowable: Throwable): Resource<T> =
+            ErrorThrowable(errorThrowable)
+
+        fun <T> errorApi(errorMessage: String): Resource<T> = ErrorApi(errorMessage)
         fun <T> loading(): Resource<T> = Loading()
     }
+}

--- a/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
@@ -249,7 +249,7 @@ class HomeFragment : Fragment() {
             .show()
     }
 
-}
+    /*
      * When all api calls are unsuccesfull hide current view, and sow new view
      * with Error Button to retry ApiCalls
      */

--- a/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
@@ -12,6 +12,7 @@ import com.melvin.ongandroid.R
 import com.melvin.ongandroid.databinding.FragmentHomeBinding
 import com.melvin.ongandroid.view.adapters.HomeWelcomeItemAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.melvin.ongandroid.model.toUI
 import com.melvin.ongandroid.view.adapters.HomeTestimonialsItemAdapter
@@ -80,6 +81,19 @@ class HomeFragment : Fragment() {
         homeViewModel.errorTestimonials.observe(viewLifecycleOwner) { error ->
             if (error != "") {
                 showSnackbar("Ha ocurrido un error obteniendo la información")
+            }
+        }
+
+        /* Observe changes in the slideError. If there is an error, display a dialog
+        * with a retry button */
+        homeViewModel.slideError.observe(viewLifecycleOwner) { error ->
+            if (error != "") {
+                showDialog(
+                    title = getString(R.string.dialog_error),
+                    message = getString(R.string.dialog_error_getting_info),
+                    positive = getString(R.string.btn_retry),
+                    callback = { homeViewModel.fetchSlides() }
+                )
             }
         }
 
@@ -192,6 +206,31 @@ class HomeFragment : Fragment() {
             else
                 incSectionWelcome.root.visibility = View.GONE
         }
+    }
+
+    /**
+     * Show dialog
+     * created on 25 April 2022 by Leonel Gomez
+     *
+     * @param title string title text
+     * @param message string message text
+     * @param negative string text in the negative button, default null (not showed)
+     * @param positive string text in the positive button, default null (not showed)
+     * @param callback function that is called when positive button is clicked, default null (no action)
+     */
+    private fun showDialog(
+        title: String,
+        message: String,
+        negative: String? = null,
+        positive: String? = null,
+        callback: (() -> Unit)? = null
+    ) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(title)
+            .setMessage(message)
+            .setNegativeButton(negative) { _, _ -> }
+            .setPositiveButton(positive) { _, _ -> callback?.invoke() }
+            .show()
     }
 
 }

--- a/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
@@ -31,6 +31,13 @@ class HomeViewModel @Inject constructor(private val repo: OngRepository) : ViewM
     private val _slideList = MutableLiveData<List<Slide>>()
     val slideList: LiveData<List<Slide>> = _slideList
 
+    /**
+     * slide error of MutableLiveData String type
+     * to catch the error of the function of getting Slide
+     * created on 25 April 2022 by Leonel Gomez
+     */
+    private val _slideError: MutableLiveData<String> = MutableLiveData()
+    val slideError: LiveData<String> = _slideError
   
     init {
         getTestimonials()
@@ -74,21 +81,26 @@ class HomeViewModel @Inject constructor(private val repo: OngRepository) : ViewM
      * Fetch slides
      * from repository
      * created on 24 April 2022 by Leonel Gomez
+     * updated on 25 April 2022 by Leonel Gomez
      */
-    private fun fetchSlides() {
+    fun fetchSlides() {
         //coroutine to get the listing asynchronously
         viewModelScope.launch(IO) {
-            repo.getSlides().collect { response ->
-                try {
-                    if (response.success)
-                        _slideList.postValue(response.data!!)
-                    else
+            repo.getSlides()
+                .catch { throwable -> _slideError.postValue(throwable.message) }
+                .collect { response ->
+                    try {
+                        if (response.success)
+                            _slideList.postValue(response.data!!)
+                        else
+                            _slideList.postValue(listOf())
+                        _slideError.postValue("")
+                    } catch (e: Exception) {
                         _slideList.postValue(listOf())
-
-                } catch (e: Exception) {
-                    _slideList.postValue(listOf())
+                        _slideError.postValue(e.message)
+                    }
                 }
-            }
         }
     }
+
 }

--- a/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
@@ -67,6 +67,8 @@ class HomeViewModel @Inject constructor(private val repo: OngRepository) : ViewM
             repo.getTestimonials().collect { testimonialsResponse ->
                 _testimonials.postValue(testimonialsResponse)
 
+            }
+        }
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,13 @@
     <string name="fragment_contact_messageHint">Escribe tu consulta</string>
     <string name="fragment_contact_button">Enviar</string>
 
+    <!-- Button texts -->
+    <string name="btn_retry">Reintentar</string>
+
+    <!-- Dialog texts -->
+    <string name="dialog_error">Error</string>
+    <string name="dialog_error_getting_info">Ha ocurrido un error obteniendo la información</string>
+
 
     <!-- Image content description in layouts -->
     <string name="content_description_loading">Cargando</string>


### PR DESCRIPTION
Catch errors on the fetching of the Slide API service and show a message with retry button
- in the fetching function get an error, the LiveData _slideError is loaded with the error message, and then in the fragment shows a dialog with the default message ("Ha ocurrido un error obteniendo la información") and a retry button with the text ("Reintentar"), if it is clicked, it calls to fetch slides again