### PR TITLE
Leonelg/ot192 43 spinner in home

### DIFF
--- a/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/HomeFragment.kt
@@ -83,6 +83,14 @@ class HomeFragment : Fragment() {
             }
         }
 
+        /* Observe if any of the three search is still in loading state
+        * The spinner is hidden when all three sections (welcome, latest news, and testimonials)
+        * have finished fetching their data. */
+        homeViewModel.isLoading.observe(viewLifecycleOwner) { loading ->
+            if(loading != null)
+                enableUI(!loading)
+        }
+
 
         //Configuration of Welcome section
         binding.incSectionWelcome.tvTitleWelcome.text =
@@ -192,6 +200,19 @@ class HomeFragment : Fragment() {
             else
                 incSectionWelcome.root.visibility = View.GONE
         }
+    }
+
+    /**
+     * Enable UI when loading data is finished
+     * created on 25 April 2022 by Leonel Gomez
+     *
+     * @param enable
+     */
+    private fun enableUI(enable : Boolean) {
+        if(enable)
+            binding.progressLoader.root.visibility = View.GONE
+        else
+            binding.progressLoader.root.visibility = View.VISIBLE
     }
 
 }

--- a/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/melvin/ongandroid/viewmodel/HomeViewModel.kt
@@ -142,7 +142,10 @@ class HomeViewModel @Inject constructor(private val repo: OngRepository) : ViewM
                         _newsState.postValue(Resource.loading())
 
                 }
-
+                //Reset loading state when it is not loading
+                if(resource !is Resource.Loading) {
+                    isNewsLoading.postValue(false)
+                }
             }
         }
     }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -36,7 +36,7 @@
             android:layout_width="219dp"
             android:layout_height="97dp"
             android:layout_marginBottom="252dp"
-            android:text="@string/retry_button"
+            android:text="@string/btn_retry"
             android:visibility="visible"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -80,4 +80,10 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
+    <!-- include loading spinner -->
+    <include
+        android:id="@+id/progress_loader"
+        layout="@layout/view_load_spinner"
+        android:visibility="gone" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,6 @@
 
     <string name="error_message_contact">Ha ocurrido un error. Intente nuevamente mas tarde</string>
     <string name="massive_error">Error General</string>
-    <string name="retry_button">Reintentar</string>
 
 
 </resources>


### PR DESCRIPTION
**Show spinner while content is loading and after finish hide it**

Entering the "Home" view displays a loading spinner which represents the loading of content.
The spinner is hidden when all three sections (welcome, latest news, and testimonials) have finished fetching their data.

- In HomeFragment: creation of enableUI function (that consist of a progressBar and a gray view blocking the screen to be used in loading state), and sets an observer to view changes in isLoading mutable live data in HomeViewModel

- In HomeViewModel: isLoading is a MediatorLiveData that contains three boolean MutableLiveData they indicate if one of the three fetching is still in loading state
For each search, there is a MutableLiveData to indicate if the search is loading
- on Init, set loading state of all search, then configure sources of loading mediator
- after collect data from each response, the isXLoading mutableLiveData is set to false.

- merge retry string button between similar incidences

