### PR TITLE
Ot192 64 home view model test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,4 +108,16 @@ dependencies {
     testImplementation "com.google.dagger:hilt-android-testing:$hilt_version"
     kaptTest "com.google.dagger:hilt-compiler:$hilt_version"
 
+    //Mockk
+    testImplementation "io.mockk:mockk:1.12.3"
+
+    //Core-Tetsing
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+
+    //Google truth
+    testImplementation "com.google.truth:truth:1.1.3"
+
+    //Coroutines Test
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1'
+
 }

--- a/app/src/test/java/com/melvin/ongandroid/LiveDataTestUtil.kt
+++ b/app/src/test/java/com/melvin/ongandroid/LiveDataTestUtil.kt
@@ -1,0 +1,64 @@
+package com.melvin.ongandroid
+
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Gets the value of a [LiveData] or waits for it to have one, with a timeout.
+ *
+ * Use this extension from host-side (JVM) tests. It's recommended to use it alongside
+ * `InstantTaskExecutorRule` or a similar mechanism to execute tasks synchronously.
+ */
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValue.removeObserver(this)
+        }
+    }
+    this.observeForever(observer)
+
+    try {
+        afterObserve.invoke()
+
+        // Don't wait indefinitely if the LiveData is not set.
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+
+    } finally {
+        this.removeObserver(observer)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/com/melvin/ongandroid/MainDispatcherRule.kt
+++ b/app/src/test/java/com/melvin/ongandroid/MainDispatcherRule.kt
@@ -1,0 +1,20 @@
+package com.melvin.ongandroid
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -1,12 +1,70 @@
 package com.melvin.ongandroid.viewmodel
 
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.melvin.ongandroid.MainDispatcherRule
+import com.melvin.ongandroid.getOrAwaitValue
+import com.melvin.ongandroid.model.News
+import com.melvin.ongandroid.model.NewsResponse
+import com.melvin.ongandroid.repository.OngRepository
+import com.melvin.ongandroid.utils.Resource
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 
 import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class HomeViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @get:Rule
+    var ruleInstantExecutor: InstantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @MockK
+    lateinit var repository: OngRepository
+
+    private val viewModel: HomeViewModel by lazy { HomeViewModel(repository) }
+
 
     @Before
     fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
     }
+
+    /** All method in viewModel are privet and executed on init block. That's is why, for now,
+     * we are using [HomeViewModel.retryApiCallsHome]. */
+    @Test
+    fun `News State should be Success  when api request of news is successful`() = runTest {
+
+        val response = NewsResponse(true, listOf(News(23)))
+
+        //Define response for latest news Api Request
+
+        coEvery { repository.fetchLatestNews() }.returns(flowOf(Resource.success(response)))
+
+        //When
+        viewModel.retryApiCallsHome()
+
+        /**Verify tha [OngRepository.fetchLatestNews] is called.
+         */
+        coVerify {
+            repository.fetchLatestNews()
+        }
+
+        //This Should be True
+        assert(viewModel.newsState.getOrAwaitValue() is Resource.Success)
+    }
+
+
+
+
 }

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -3,10 +3,7 @@ package com.melvin.ongandroid.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.melvin.ongandroid.MainDispatcherRule
 import com.melvin.ongandroid.getOrAwaitValue
-import com.melvin.ongandroid.model.GenericResponse
-import com.melvin.ongandroid.model.News
-import com.melvin.ongandroid.model.NewsResponse
-import com.melvin.ongandroid.model.Slide
+import com.melvin.ongandroid.model.*
 import com.melvin.ongandroid.repository.OngRepository
 import com.melvin.ongandroid.utils.Resource
 import com.squareup.okhttp.MediaType
@@ -168,6 +165,21 @@ class HomeViewModelTest {
         assert(listStateEmpty.isEmpty())
     }
 
+    @Test
+    fun `Should be True when Response testimontial is successful`() = runTest {
+        val listTestimonial = mutableListOf(HomeTestimonials(1))
+        val responseTestimonial = GenericResponse(true, listTestimonial)
+
+        coEvery { repository.getTestimonials() }.returns(flowOf(responseTestimonial))
+        //When
+        viewModel.getTestimonials()
+
+        //Verify
+        coVerify { repository.getTestimonials() }
+
+        assert(viewModel.testimonials.getOrAwaitValue().data.isNotEmpty())
+
+    }
 
 
 }

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -178,22 +177,21 @@ class HomeViewModelTest {
         //Verify
         coVerify { repository.getTestimonials() }
 
-
-
         assert(viewModel.testimonials.getOrAwaitValue().data.isNotEmpty())
         assert(viewModel.errorTestimonials.getOrAwaitValue().isEmpty())
 
     }
 
-
+    /**We should fix testimonials for testing. Probably, changing logic in repository.*/
     @Test
     fun `Test Error for testimonails Slides`() = runTest {
         val exception = IOException()
 
-        coEvery { repository.getTestimonials().catch {  } }.throws(exception)
-            .andThen( flowOf<GenericResponse<MutableList<HomeTestimonials>>>
-                (GenericResponse(true, mutableListOf())).catch {e->
-                exception.localizedMessage!! })
+        coEvery { repository.getTestimonials().catch { } }.throws(exception)
+            .andThen(flowOf<GenericResponse<MutableList<HomeTestimonials>>>
+                (GenericResponse(true, mutableListOf())).catch { e ->
+                exception.localizedMessage!!
+            })
 
         //When
         viewModel.getTestimonials()

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -117,7 +117,7 @@ class HomeViewModelTest {
     @Test
     fun `NewsState should catch exceptions`() = runTest {
         val exception = IOException()
-
+        //Simulated Exceptions
         coEvery { repository.fetchLatestNews() }.returns(flowOf(Resource.errorThrowable(exception)))
 
         //When

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -1,0 +1,12 @@
+package com.melvin.ongandroid.viewmodel
+
+import org.junit.Assert.*
+
+import org.junit.Before
+
+class HomeViewModelTest {
+
+    @Before
+    fun setUp() {
+    }
+}

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -3,8 +3,10 @@ package com.melvin.ongandroid.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.melvin.ongandroid.MainDispatcherRule
 import com.melvin.ongandroid.getOrAwaitValue
+import com.melvin.ongandroid.model.GenericResponse
 import com.melvin.ongandroid.model.News
 import com.melvin.ongandroid.model.NewsResponse
+import com.melvin.ongandroid.model.Slide
 import com.melvin.ongandroid.repository.OngRepository
 import com.melvin.ongandroid.utils.Resource
 import com.squareup.okhttp.MediaType
@@ -130,9 +132,22 @@ class HomeViewModelTest {
         }
 
         assert(viewModel.newsState.getOrAwaitValue() is Resource.ErrorThrowable)
+    }
 
+    @Test
+    fun `Slides should not be empty when Request is successful`() = runTest {
+        val listSlide = listOf(Slide(1, "uno"), Slide(2, "Dos"))
+        val responseSlide = GenericResponse(true, data = listSlide)
 
+        coEvery { repository.getSlides() }.returns(flowOf(responseSlide))
 
+        //When
+        viewModel.retryApiCallsHome()
+
+        //Verify
+        coVerify { repository.getSlides() }
+
+        assert(viewModel.slideList.getOrAwaitValue().isNotEmpty())
     }
 
 

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -150,5 +150,24 @@ class HomeViewModelTest {
         assert(viewModel.slideList.getOrAwaitValue().isNotEmpty())
     }
 
+    @Test
+    fun `Test Handle error`() = runTest {
+        // Bad Response
+        val badResponse = GenericResponse(false, data = listOf<Slide>())
+
+        coEvery { repository.getSlides() }.returns(flowOf(badResponse))
+
+        //When
+        viewModel.retryApiCallsHome()
+
+        //Verify
+        coVerify { repository.getSlides() }
+
+        val listStateEmpty = viewModel.slideList.getOrAwaitValue()
+
+        assert(listStateEmpty.isEmpty())
+    }
+
+
 
 }

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -14,8 +14,6 @@ import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.*
-
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -62,6 +60,28 @@ class HomeViewModelTest {
 
         //This Should be True
         assert(viewModel.newsState.getOrAwaitValue() is Resource.Success)
+    }
+
+    @Test
+    fun `check if List of News in ViewModel is the same that repo `()= runTest {
+
+        val response = NewsResponse(true, listOf(News(23)))
+
+        //Define response for latest news Api Request
+
+        coEvery { repository.fetchLatestNews() }.returns(flowOf(Resource.success(response)))
+
+        //When
+        viewModel.retryApiCallsHome()
+
+        /**Verify tha [OngRepository.fetchLatestNews] is called.
+         */
+        coVerify {
+            repository.fetchLatestNews()
+        }
+
+        //This Should be True
+        assert(viewModel.newsState.getOrAwaitValue().data?.novedades?.firstOrNull() == response.novedades.first())
     }
 
 

--- a/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
+++ b/app/src/test/java/com/melvin/ongandroid/viewmodel/HomeViewModelTest.kt
@@ -22,6 +22,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import retrofit2.Response
+import java.io.IOException
 
 @ExperimentalCoroutinesApi
 class HomeViewModelTest {
@@ -112,6 +113,26 @@ class HomeViewModelTest {
 
         // This Shuold be True
         assert(viewModel.newsState.getOrAwaitValue() is Resource.ErrorApi)
+    }
+
+    @Test
+    fun `NewsState should catch exceptions`() = runTest {
+        val exception = IOException()
+
+        coEvery { repository.fetchLatestNews() }.returns(flowOf(Resource.errorThrowable(exception)))
+
+        //When
+        viewModel.retryApiCallsHome()
+
+        //Verify
+        coVerify {
+            repository.fetchLatestNews()
+        }
+
+        assert(viewModel.newsState.getOrAwaitValue() is Resource.ErrorThrowable)
+
+
+
     }
 
 


### PR DESCRIPTION
Se realizaron los siguientes Test en HomViewModel:

1.  Cuando la respuesta de News es Exitosa
2. Si el listado de la api es la misma que el repositorio.
3.  Simular error de Respuesta API en News. Manejo de estado
4. Manejo de excepciones en el listado del noticias
5. Listado de Slides Exitosas
6.  Error en la respuesta de la api/slides
7. Respuesta exitosa en api/testimonials
8. Error en respuesta Testimonials

Se utilizó la librería Mockk, Test Corrutinas de Kotlin.
Se Agregó un main Dispatchers para dar un Scope de tipo Main(Test) para los Unit Test.
Se agrego un archivo para poder testear LiveData