### PR TITLE
Ot192 46 integracion members

### DIFF
--- a/app/src/main/java/com/melvin/ongandroid/model/Members.kt
+++ b/app/src/main/java/com/melvin/ongandroid/model/Members.kt
@@ -1,0 +1,21 @@
+package com.melvin.ongandroid.model
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Members(
+    var id: Int = 0,
+    var name: String = "",
+    var image: String = "",
+    var description: String = "",
+    var facebookUrl: String = "",
+    var linkedinUrl: String = "",
+    @SerializedName("created_at")
+    var createdAt: String = "",
+    @SerializedName("updated_at")
+    var updatedAt: String = "",
+    @SerializedName("deleted_at")
+    var deletedAt: String? = "",
+    @SerializedName("group_id")
+    var groupId: Any = Any()
+)

--- a/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
+++ b/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
@@ -1,11 +1,7 @@
 package com.melvin.ongandroid.repository
 
 
-import com.melvin.ongandroid.model.Contact
-import com.melvin.ongandroid.model.HomeTestimonials
-import com.melvin.ongandroid.model.GenericResponse
-import com.melvin.ongandroid.model.NewsResponse
-import com.melvin.ongandroid.model.Slide
+import com.melvin.ongandroid.model.*
 import com.melvin.ongandroid.services.OngApiService
 import com.melvin.ongandroid.utils.Resource
 import kotlinx.coroutines.flow.Flow
@@ -53,4 +49,28 @@ class OngRepository @Inject constructor(private val apiService: OngApiService) {
         emit(apiService.getSlides())
 
     }
+
+    /**
+     * Fetch Members from [https://ongapi.alkemy.org/api/members].
+     * When:
+     * [retrofit2.Response] is successfull and [GenericResponse] success is true -->
+     * Emits [Resource.Success]
+     *
+     * [retrofit2.Response] is not successfull or [GenericResponse] success false ->
+     * emits [Resource.ErrorApi]
+     *
+     * Exceptions  are caught with flow API [catch]. --> Emits [Resource.ErrorThrowable]
+     */
+
+    suspend fun fetchMembers() =
+        flow<Resource<GenericResponse<List<Members>>>> {
+            val responseMembers = apiService.fetchMembers()
+            when {
+                responseMembers.isSuccessful && responseMembers.body()!!.success ->
+                    emit(Resource.success(responseMembers.body()!!))
+
+                else -> emit(Resource.errorApi(responseMembers.errorBody().toString()))
+            }
+        }.catch { e -> emit(Resource.errorThrowable(e)) }
+
 }

--- a/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
+++ b/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
@@ -36,22 +36,21 @@ class OngRepository @Inject constructor(private val apiService: OngApiService) {
     }
 
 
+    // Function that emits a GenericResponse, containing a contact response
+    suspend fun sendContact(contact: Contact): Flow<GenericResponse<List<Contact>>> = flow {
+        emit(apiService.sendContact(contact))
+    }
 
-// Function that emits a GenericResponse, containing a contact response
-suspend fun sendContact(contact: Contact): Flow<GenericResponse<List<Contact>>> = flow {
-    emit(apiService.sendContact(contact))
-}
+    /**
+     * Get slides
+     * Repository function that return the list of slides from the API
+     * created on 24 April 2022 by Leonel Gomez
+     *
+     * @return the list of Slides emitted by upstream
+     */
+    suspend fun getSlides(): Flow<GenericResponse<List<Slide>>> = flow {
+        //Collects the value emitted by the upstream
+        emit(apiService.getSlides())
 
-/**
- * Get slides
- * Repository function that return the list of slides from the API
- * created on 24 April 2022 by Leonel Gomez
- *
- * @return the list of Slides emitted by upstream
- */
-suspend fun getSlides(): Flow<GenericResponse<List<Slide>>> = flow {
-    //Collects the value emitted by the upstream
-    emit(apiService.getSlides())
-
-}
+    }
 }

--- a/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
+++ b/app/src/main/java/com/melvin/ongandroid/repository/OngRepository.kt
@@ -56,7 +56,7 @@ class OngRepository @Inject constructor(private val apiService: OngApiService) {
      * [retrofit2.Response] is successfull and [GenericResponse] success is true -->
      * Emits [Resource.Success]
      *
-     * [retrofit2.Response] is not successfull or [GenericResponse] success false ->
+     * [retrofit2.Response] is not successfull and [GenericResponse] success false ->
      * emits [Resource.ErrorApi]
      *
      * Exceptions  are caught with flow API [catch]. --> Emits [Resource.ErrorThrowable]
@@ -66,8 +66,13 @@ class OngRepository @Inject constructor(private val apiService: OngApiService) {
         flow<Resource<GenericResponse<List<Members>>>> {
             val responseMembers = apiService.fetchMembers()
             when {
-                responseMembers.isSuccessful && responseMembers.body()!!.success ->
+                responseMembers.isSuccessful && responseMembers.body()!!.success -> {
                     emit(Resource.success(responseMembers.body()!!))
+                }
+
+                responseMembers.isSuccessful  && !responseMembers.body()!!.success->{
+                    emit(Resource.errorApi("Error from API"))
+                }
 
                 else -> emit(Resource.errorApi(responseMembers.errorBody().toString()))
             }

--- a/app/src/main/java/com/melvin/ongandroid/services/OngApiService.kt
+++ b/app/src/main/java/com/melvin/ongandroid/services/OngApiService.kt
@@ -1,10 +1,6 @@
 package com.melvin.ongandroid.services
 
-import com.melvin.ongandroid.model.Contact
-import com.melvin.ongandroid.model.HomeTestimonials
-import com.melvin.ongandroid.model.GenericResponse
-import com.melvin.ongandroid.model.NewsResponse
-import com.melvin.ongandroid.model.Slide
+import com.melvin.ongandroid.model.*
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -44,6 +40,14 @@ interface OngApiService {
         @Query("skip") skip: Int? = null,
         @Query("limit") limit: Int? = null,
     ): GenericResponse<List<Slide>>
+
+    /** Fetch Members from
+     * [https://ongapi.alkemy.org/api/members]
+     * Returns a [Response] (RetroFit) of [GenericResponse] with
+     * a [List] of [Members]
+     */
+    @GET("members")
+    suspend fun fetchMembers(): Response<GenericResponse<List<Members>>>
 
 
 }

--- a/app/src/main/java/com/melvin/ongandroid/view/adapters/MemberListAdapter.kt
+++ b/app/src/main/java/com/melvin/ongandroid/view/adapters/MemberListAdapter.kt
@@ -1,0 +1,101 @@
+package com.melvin.ongandroid.view.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.melvin.ongandroid.databinding.ItemRecyclerAboutUsBinding
+import com.melvin.ongandroid.model.MemberUI
+import com.melvin.ongandroid.model.Members
+
+/**
+ * Class for ListAdapter that replaces [MemberItemAdapter].
+ * Now uses [Members] model from api response. Replaces
+ * [MemberUI] used to mock responseC
+ */
+class MemberListAdapter() :
+    ListAdapter<Members, RecyclerView.ViewHolder>
+        (DiffUtilCallback()) {
+
+    var onItemClicked: ((Members) -> Unit)? = null
+
+    /**
+     * On create view holder
+     *
+     * @param parent
+     * @param viewType
+     * @return constructor of ViewHolder referencing inflated layout
+     */
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val binding = ItemRecyclerAboutUsBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return ViewHolder(binding)
+    }
+
+    /**
+     * On bind view holder
+     * Connect the item in the position of the list with the Holder
+     *
+     * @param holder
+     * @param position of the item in the list
+     */
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val viewHolder: ViewHolder = holder as ViewHolder
+        viewHolder.bind(getItem(position), onItemClicked)
+    }
+
+    /**
+     * View holder
+     *
+     * @property binding reference to item layout
+     * @constructor Create empty View holder
+     */
+    class ViewHolder(private val binding: ItemRecyclerAboutUsBinding) :
+        RecyclerView.ViewHolder(binding.cvAboutUs) {
+
+        /**
+         * Bind
+         * Used to connect items to layout
+         *
+         * @param value the item
+         * @param listener a function to invoke when the item in clicked
+         */
+        internal fun bind(
+            value: Members,
+            listener: ((Members) -> Unit)?,
+        ) {
+            with(binding) {
+                //Set texts
+                tvName.text = value.name
+                tvDescription.text = value.description
+                //Load the image url and set it on this ImageView
+                imgMember.load(value.image)
+
+                cvAboutUs.setOnClickListener {
+                    listener?.invoke(value)
+                }
+            }
+        }
+    }
+
+    /**
+     * Diff util callback
+     *
+     * @constructor Create empty Diff util callback
+     */
+    class DiffUtilCallback : DiffUtil.ItemCallback<Members>(){
+        override fun areItemsTheSame(oldItem: Members, newItem: Members): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: Members, newItem: Members): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+    }
+}

--- a/app/src/main/java/com/melvin/ongandroid/viewmodel/AboutUsViewModel.kt
+++ b/app/src/main/java/com/melvin/ongandroid/viewmodel/AboutUsViewModel.kt
@@ -3,9 +3,15 @@ package com.melvin.ongandroid.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.melvin.ongandroid.model.GenericResponse
 import com.melvin.ongandroid.model.MemberUI
+import com.melvin.ongandroid.model.Members
 import com.melvin.ongandroid.repository.OngRepository
+import com.melvin.ongandroid.utils.Resource
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,6 +24,12 @@ class AboutUsViewModel @Inject constructor(private val repo: OngRepository) : Vi
     private val _memberList = MutableLiveData<List<MemberUI>>()
     val memberList: LiveData<List<MemberUI>> = _memberList
 
+    private val _membersState: MutableLiveData<Resource<GenericResponse<List<Members>>>> =
+        MutableLiveData(Resource.loading())
+    val membersState: LiveData<Resource<GenericResponse<List<Members>>>> = _membersState
+
+
+
     init {
         //TODO: Hardcoded Member list, replace with data from API
         //TODO: After fetching data, map Member to MemberUI object -> map { it.toUI() }
@@ -28,5 +40,37 @@ class AboutUsViewModel @Inject constructor(private val repo: OngRepository) : Vi
                 description = "Descripción ${(1..100).random()}"
             )
         }
+        fetchMembers()
     }
+
+    /**
+     * Fetch Members from [OngRepository].Handles States when:
+     * [Resource.Success] -> Post values with list of members.
+     * [Resource.ErrorApi] -->Post Values with Error message
+     * [Resource.ErrorThrowable] -> Catchs Exceptions.
+     * [Resource.Loading] --> Handle State when loading
+     *
+     * IMPORTANT: this functions uses double bang operator !! because handles all possible
+     * states from Response. This way we ensure that is never null.
+     */
+
+    fun fetchMembers(){
+        viewModelScope.launch(IO) {
+            repo.fetchMembers().collect{ resource->
+                when(resource){
+                    is Resource.Success ->
+                        _membersState.postValue(Resource.success(resource.data!!))
+
+                    is Resource.ErrorApi ->
+                        _membersState.postValue(Resource.errorApi(resource.errorMessage!!))
+
+                    is Resource.ErrorThrowable ->
+                        _membersState.postValue(Resource.errorThrowable(resource.errorThrowable!!))
+
+                    is Resource.Loading -> _membersState.postValue(Resource.loading())
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
### Ticket 46: Integración Lista de Miembros.

Cambios realizados:
•	Agregué un modelo Members que replica la respuesta de https://ongapi.alkemy.org/api/members.
•	Función  fetchmembers en OngApiService que busca los miembros desde el endpoint antes mencionado. Es de Tipo Response ( RetroFit) con un wrapper de GenericResponse y en caso de ser exitoso devuelve una lista de Members.
•	Función en OngRepository que maneja la  respuesta del endpoint. En caso de que sea exitosa, se emite un wrapper Resource.Success con el listado. En caso de errores de la API se emite un Resource.ErrorApi y finalmente se manejan las excepciones con Flow.catch y se emite un Resource.ErrorThrowable.
•	Se creo un nuevo ListAdapter  llamado MemberListAdapter que utiliza el Members  como modelo, con el objetivo de reemplazar MembersItemAdapter.kt. 
•	Creación de función initRecylcerView en AboutUsFragment. Define la cantidad de columnas dado la orientación del celular. A su vez, maneja los estados de la respuesta. Cuando:
      o	Esta cargando -> Resource.Loading -> Muestra progress Spinner, oculta Section About Us.
      o	Es exitosa -> Resource.Succes -> Muestra Sección AboutUs, envía lista de miembros al adaptador y oculta el spinner
      o	Errores -> Será implementado en el ticket #47.
